### PR TITLE
Handle empty 'items' array

### DIFF
--- a/src/mui-nested-menu/components/nestedMenuItemsFromObject.tsx
+++ b/src/mui-nested-menu/components/nestedMenuItemsFromObject.tsx
@@ -21,7 +21,7 @@ export function nestedMenuItemsFromObject({
   return items.map(item => {
     const {leftIcon, rightIcon, label, items, callback} = item;
 
-    if (items) {
+    if (items && items.length > 0) {
       // Recurse deeper
       return (
         <NestedMenuItem


### PR DESCRIPTION
Don't show the arrow icon if the 'items' array is empty