### PR TITLE
Issue #7: NestedMenuItem onClick event not behaving as expected

### DIFF
--- a/src/mui-nested-menu/components/IconMenuItem.tsx
+++ b/src/mui-nested-menu/components/IconMenuItem.tsx
@@ -39,7 +39,6 @@ const IconMenuItem = forwardRef<HTMLLIElement, IconMenuItemProps>(
         {...MenuItemProps}
         ref={ref}
         className={className}
-        onClick={onClick}
         {...props}
       >
         <FlexBox>


### PR DESCRIPTION
Fixes onClick event on NestedMenuItem

```
export const NestedCategoryItem = ({children}: {children: React.ReactNode}) => {
  const clickHandler = (e) => {
    console.log('clicked');
    console.log(e);
  };

  return (
    <NestedMenuItem
      label="Test Category"
      parentMenuOpen={true}
      rightIcon={React.Children.count(children) > 0 ? <ArrowRightIcon /> : null}
      style={{marginRight: 8}}
      onClick={() => console.log("click clack")}  // <<< this line
    >
      {React.Children.count(children) &&
        React.Children.map(children, child => child)}
    </NestedMenuItem>
  );
};
```

See issue #7.