### PR TITLE
Issue #5: Allow passing props for the Menu component in NestedMenuItem

### DIFF
--- a/src/mui-nested-menu/components/IconMenuItem.tsx
+++ b/src/mui-nested-menu/components/IconMenuItem.tsx
@@ -30,10 +30,7 @@ interface IconMenuItemProps {
 }
 
 const IconMenuItem = forwardRef<HTMLLIElement, IconMenuItemProps>(
-  (
-    {leftIcon, rightIcon, label, MenuItemProps, className, ...props},
-    ref,
-  ) => {
+  ({leftIcon, rightIcon, label, MenuItemProps, className, ...props}, ref) => {
     return (
       <StyledMenuItem
         {...MenuItemProps}

--- a/src/mui-nested-menu/components/NestedMenuItem.tsx
+++ b/src/mui-nested-menu/components/NestedMenuItem.tsx
@@ -15,7 +15,7 @@ export interface NestedMenuItemProps extends Omit<MenuItemProps, 'button'> {
   disabled?: boolean;
   ContainerProps?: React.HTMLAttributes<HTMLElement> &
     React.RefAttributes<HTMLElement | null>;
-  MenuProps?: Omit<MenuProps, 'children'>;
+  MenuProps?: Partial<Omit<MenuProps, 'children'>>;
   button?: true | undefined;
 }
 
@@ -32,6 +32,7 @@ const NestedMenuItem = React.forwardRef<
     className,
     tabIndex: tabIndexProp,
     ContainerProps: ContainerPropsProp = {},
+    MenuProps,
     ...MenuItemProps
   } = props;
 
@@ -149,6 +150,7 @@ const NestedMenuItem = React.forwardRef<
         onClose={() => {
           setIsSubMenuOpen(false);
         }}
+        {...MenuProps}
       >
         <div ref={menuContainerRef} style={{pointerEvents: 'auto'}}>
           {children}


### PR DESCRIPTION
Allow passing props for the Menu component in NestedMenuItem.

```
<NestedMenuItem
	leftIcon={<AdbIcon />}
	rightIcon={<FlutterDashIcon />}
	label="Top Level"
	parentMenuOpen={open}
	MenuProps={{sx: {bgcolor: 'red'}}}  // <<< something like this
>
....
</NestedMenuItem>
```

See issue #5.