### PR TITLE
Issue #10: Added menuItems prop to ContextMenu

### DIFF
--- a/src/mui-nested-menu/components/ContextMenu.tsx
+++ b/src/mui-nested-menu/components/ContextMenu.tsx
@@ -5,6 +5,7 @@ import {MenuItemData} from '../definitions';
 
 export interface ContextMenuProps {
   children?: React.ReactNode;
+  menuItems?: React.ReactNode[];
   menuItemsData?: MenuItemData[];
 }
 
@@ -14,7 +15,7 @@ interface Position {
 }
 
 const ContextMenu = forwardRef<HTMLDivElement, ContextMenuProps>(
-  ({children, menuItemsData}, ref) => {
+  ({children, menuItems, menuItemsData}, ref) => {
     const [menuPosition, setMenuPosition] = useState<Position>(null);
 
     const [mouseDownPosition, setMouseDownPosition] = useState<Position>(null);
@@ -40,11 +41,14 @@ const ContextMenu = forwardRef<HTMLDivElement, ContextMenuProps>(
       }
     };
 
-    const menuItems = nestedMenuItemsFromObject({
-      menuItemsData: menuItemsData,
-      isOpen: !!menuPosition,
-      handleClose: handleItemClick,
-    });
+    const menuContents =
+      menuItems ??
+      (menuItemsData &&
+        nestedMenuItemsFromObject({
+          menuItemsData: menuItemsData,
+          isOpen: !!menuPosition,
+          handleClose: handleItemClick,
+        }));
 
     return (
       <div
@@ -60,7 +64,7 @@ const ContextMenu = forwardRef<HTMLDivElement, ContextMenuProps>(
           anchorReference="anchorPosition"
           anchorPosition={menuPosition}
         >
-          {menuItems}
+          {menuContents}
         </Menu>
         {children}
       </div>

--- a/src/pages/ContextMenuPage.tsx
+++ b/src/pages/ContextMenuPage.tsx
@@ -9,8 +9,14 @@ import SaveIcon from '@mui/icons-material/SaveRounded';
 import AdbIcon from '@mui/icons-material/Adb';
 import FlutterDashIcon from '@mui/icons-material/FlutterDash';
 
-import {ContextMenu, MenuItemData} from '@mui-nested-menu/index';
+import {
+  ContextMenu,
+  IconMenuItem,
+  MenuItemData,
+  NestedMenuItem,
+} from '@mui-nested-menu/index';
 import {ThemeProvider as MTP, createTheme} from '@mui/material/styles';
+import {Divider} from '@mui/material';
 
 const menuItemsData: MenuItemData[] = [
   {
@@ -71,8 +77,46 @@ export const ContextMenuPage = () => {
   return (
     <>
       <PageHeader />
-      <P>When right clicked, it will open a context menu.</P>
+      <P>
+        When right clicked, it will open a context menu. Either provide the
+        <Code>menuItems</Code> prop or the <Code>menuItemsData</Code> prop.
+      </P>
 
+      <Subheading>menuItems</Subheading>
+      <P>
+        <Code>menuItems</Code> allows you to insert other items such as
+        dividers.
+      </P>
+      <SampleBox>
+        <MTP theme={createTheme()}>
+          <ContextMenu
+            menuItems={[
+              <IconMenuItem key="i1" label="Item 1" rightIcon={<NewIcon />} />,
+              <Divider key="i2" />,
+              <IconMenuItem key="i3" label="Item 2" rightIcon={<SaveIcon />} />,
+            ]}
+          >
+            <div>Right Click Me!</div>
+          </ContextMenu>
+        </MTP>
+      </SampleBox>
+      <CodeBlock
+        code={`<ContextMenu
+  menuItems={[
+    <IconMenuItem key="i1" label="Item 1" rightIcon={<NewIcon />} />,
+    <Divider key="i2" />,
+    <IconMenuItem key="i3" label="Item 2" rightIcon={<SaveIcon />} />,
+  ]}
+>
+  <div>Right Click Me!</div>
+</ContextMenu>`}
+      />
+
+      <Subheading>menuItemsData</Subheading>
+      <P>
+        <Code>menuItemsData</Code> allows you to create a menu from an object
+        format. It is more limited in what it can do.
+      </P>
       <SampleBox>
         <MTP theme={createTheme()}>
           <ContextMenu menuItemsData={menuItemsData}>
@@ -85,12 +129,10 @@ export const ContextMenuPage = () => {
   <div>Right Click Me!</div>
 </ContextMenu>`}
       />
-
       <Subheading>Data Structure</Subheading>
       <P>
         The <Code>menuItemsData</Code> variable looks like the following:
       </P>
-
       <CodeBlock
         code={`const menuItemsData: MenuItemData[] = [
   {


### PR DESCRIPTION
See user concern in issue #10.

Context menu will now have a new prop `menuItems`. This allows more flexibility and just a generally nicer way to define a context menu.

```
          <ContextMenu
            menuItems={[
              <IconMenuItem key="i1" label="Item 1" rightIcon={<NewIcon />} />,
              <Divider key="i2" />,
              <IconMenuItem key="i3" label="Item 2" rightIcon={<SaveIcon />} />,
            ]}
          >
            <div>Right Click Me!</div>
          </ContextMenu>
```