### PR TITLE
Fix MUI imports to avoid pulling in unused modules

### DIFF
--- a/src/mui-nested-menu/components/ContextMenu.tsx
+++ b/src/mui-nested-menu/components/ContextMenu.tsx
@@ -1,5 +1,5 @@
 import React, {useState, forwardRef} from 'react';
-import {Menu} from '@mui/material';
+import Menu from '@mui/material/Menu';
 import {nestedMenuItemsFromObject} from './nestedMenuItemsFromObject';
 import {MenuItemData} from '../definitions';
 

--- a/src/mui-nested-menu/components/IconMenuItem.tsx
+++ b/src/mui-nested-menu/components/IconMenuItem.tsx
@@ -1,5 +1,6 @@
 import React, {forwardRef, RefObject} from 'react';
-import {MenuItem, MenuItemProps, Typography} from '@mui/material';
+import MenuItem, {MenuItemProps} from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
 import {Box, styled} from '@mui/system';
 
 const StyledMenuItem = styled(MenuItem)({

--- a/src/mui-nested-menu/components/IconMenuItem.tsx
+++ b/src/mui-nested-menu/components/IconMenuItem.tsx
@@ -1,7 +1,8 @@
 import React, {forwardRef, RefObject} from 'react';
 import MenuItem, {MenuItemProps} from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
-import {Box, styled} from '@mui/system';
+import Box from '@mui/system/Box';
+import styled from '@mui/material/styles/styled';
 
 const StyledMenuItem = styled(MenuItem)({
   paddingLeft: '4px',

--- a/src/mui-nested-menu/components/NestedDropdown.tsx
+++ b/src/mui-nested-menu/components/NestedDropdown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {nestedMenuItemsFromObject} from './nestedMenuItemsFromObject';
-import {Button, ButtonProps, Menu, MenuProps} from '@mui/material';
+import Button, {ButtonProps} from '@mui/material/Button';
+import Menu, {MenuProps} from '@mui/material/Menu';
 import {ChevronDown} from '../icons/ChevronDown';
 import {MenuItemData} from '..';
 

--- a/src/mui-nested-menu/components/NestedMenuItem.tsx
+++ b/src/mui-nested-menu/components/NestedMenuItem.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useRef, useImperativeHandle} from 'react';
 import {IconMenuItem} from './IconMenuItem';
-import {Menu, MenuItemProps, MenuProps} from '@mui/material';
+import Menu, {MenuProps} from '@mui/material/Menu';
+import {MenuItemProps} from '@mui/material/MenuItem';
 import {ChevronRight} from '../icons/ChevronRight';
 
 export interface NestedMenuItemProps extends Omit<MenuItemProps, 'button'> {

--- a/src/mui-nested-menu/icons/ChevronDown.tsx
+++ b/src/mui-nested-menu/icons/ChevronDown.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {SvgIcon, SvgIconProps} from '@mui/material';
+import SvgIcon, {SvgIconProps} from '@mui/material/SvgIcon';
 
 export const ChevronDown = (props: SvgIconProps) => {
   return (

--- a/src/mui-nested-menu/icons/ChevronRight.tsx
+++ b/src/mui-nested-menu/icons/ChevronRight.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {SvgIcon, SvgIconProps} from '@mui/material';
+import SvgIcon, {SvgIconProps} from '@mui/material/SvgIcon';
 
 export const ChevronRight = (props: SvgIconProps) => {
   return (


### PR DESCRIPTION
The way the `mui` modules are currently imported pulls the whole `mui` packages when bundled with a bundler like webpack. This PR updates the imports declaration from `mui` modules to use the full path [as recommended ](https://mui.com/material-ui/guides/minimizing-bundle-size/#option-1).

closes https://github.com/steviebaa/mui-nested-menu/issues/17

Here are the results of this PR after bundling it in one of my apps using `webpack` analysed with https://statoscope.tech/:

Before:
<kbd><img src="https://user-images.githubusercontent.com/2046871/178029802-505a5900-1781-415c-8ae4-8022af16b7ff.png" /></kbd> 

After:
<kbd><img src="https://user-images.githubusercontent.com/2046871/178029858-77a5d566-f7a0-4204-a7dc-75ca49e7d766.png" /></kbd>

In real use, I saw a decrease in my total bundle size of 47kB.