### PR TITLE
Set main as index.js

### DIFF
--- a/src/mui-nested-menu/template-package.json
+++ b/src/mui-nested-menu/template-package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "homepage": "https://mui-nested-menu.vercel.app/",
   "description": "Inifintely deep nested menu items for MUI 5.",
-  "main": "index.ts",
+  "main": "index.js",
   "keywords": [
     "material",
     "design",


### PR DESCRIPTION
Resolves Failed to resolve entry for package "mui-nested-menu". The package may have incorrect main/module/exports specified in its package. when using with vite