### PR TITLE
Add disabled and sx props to MenuItemData

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following items and interfaces are exported from the package:
 Pull requests for <a href="https://github.com/steviebaa/mui-nested-menu">the project</a> are more than welcome. Please make sure to stick to the coding style used throughout the project.
 
 1. Clone the project from GitHub - it is a monorepo.
-2. `yarn && yarn start` and you should see the docs on `localhost:3001`.
+2. `yarn && yarn dev` and you should see the docs on `localhost:3001`.
 3. Create a new branch
 4. Make your changes
 5. Open a pull request

--- a/apps/docs/src/pages/NestedDropdownPage.tsx
+++ b/apps/docs/src/pages/NestedDropdownPage.tsx
@@ -38,6 +38,7 @@ const menuItemsData: MenuItemData = {
 					label: 'Option 2',
 					leftIcon: <SaveAsIcon />,
 					callback: () => console.log('Save As > Option 2 clicked'),
+					disabled: true,
 				},
 			],
 		},
@@ -53,6 +54,7 @@ const menuItemsData: MenuItemData = {
 							label: 'Option 1',
 							rightIcon: <SaveAsIcon />,
 							callback: () => console.log('Export > FT1 > O1 clicked'),
+							sx: { color: '#FF0000' },
 						},
 						{
 							label: 'Option 2',
@@ -131,6 +133,7 @@ export const NestedDropdownPage = () => {
           label: 'Option 2',
           leftIcon: <SaveAsIcon />,
           callback: () => console.log('Save As > Option 2 clicked'),
+          disabled: true,
         },
       ],
     },
@@ -146,6 +149,7 @@ export const NestedDropdownPage = () => {
               label: 'Option 1',
               rightIcon: <SaveAsIcon />,
               callback: () => console.log('Export > FT1 > O1 clicked'),
+              sx: { color: '#FF0000' },
             },
             {
               label: 'Option 2',

--- a/packages/mui-nested-menu/src/components/IconMenuItem.tsx
+++ b/packages/mui-nested-menu/src/components/IconMenuItem.tsx
@@ -3,7 +3,7 @@ import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/system/Box';
 import styled from '@mui/material/styles/styled';
-import { SxProps } from '@mui/system';
+import { SxProps } from '@mui/system/styleFunctionSx';
 
 const StyledMenuItem = styled(MenuItem)({
 	paddingLeft: '4px',

--- a/packages/mui-nested-menu/src/components/IconMenuItem.tsx
+++ b/packages/mui-nested-menu/src/components/IconMenuItem.tsx
@@ -3,6 +3,7 @@ import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/system/Box';
 import styled from '@mui/material/styles/styled';
+import { SxProps } from '@mui/system';
 
 const StyledMenuItem = styled(MenuItem)({
 	paddingLeft: '4px',
@@ -29,6 +30,8 @@ interface IconMenuItemProps {
 	className?: string;
 	MenuItemProps?: MenuItemProps;
 	ref?: RefObject<HTMLLIElement>;
+	disabled?: boolean;
+	sx?: SxProps;
 }
 
 const IconMenuItem = forwardRef<HTMLLIElement, IconMenuItemProps>(

--- a/packages/mui-nested-menu/src/components/nestedMenuItemsFromObject.tsx
+++ b/packages/mui-nested-menu/src/components/nestedMenuItemsFromObject.tsx
@@ -3,7 +3,7 @@ import { NestedMenuItem } from './NestedMenuItem';
 import { IconMenuItem } from './IconMenuItem';
 import { MenuItemData } from '../definitions';
 
-export interface nesteMenuItemsFromObjectProps {
+export interface nestedMenuItemsFromObjectProps {
 	menuItemsData: MenuItemData[];
 	isOpen: boolean;
 	handleClose: () => void;
@@ -17,9 +17,9 @@ export function nestedMenuItemsFromObject({
 	menuItemsData: items,
 	isOpen,
 	handleClose,
-}: nesteMenuItemsFromObjectProps) {
+}: nestedMenuItemsFromObjectProps) {
 	return items.map((item) => {
-		const { leftIcon, rightIcon, label, items, callback } = item;
+		const { leftIcon, rightIcon, label, items, callback, sx, disabled } = item;
 
 		if (items && items.length > 0) {
 			// Recurse deeper
@@ -30,6 +30,8 @@ export function nestedMenuItemsFromObject({
 					rightIcon={rightIcon}
 					label={label}
 					parentMenuOpen={isOpen}
+					sx={sx}
+					disabled={disabled}
 				>
 					{/* Call this function to nest more items */}
 					{nestedMenuItemsFromObject({
@@ -51,6 +53,8 @@ export function nestedMenuItemsFromObject({
 						handleClose();
 						callback && callback();
 					}}
+					sx={sx}
+					disabled={disabled}
 				/>
 			);
 		}

--- a/packages/mui-nested-menu/src/definitions.ts
+++ b/packages/mui-nested-menu/src/definitions.ts
@@ -1,4 +1,4 @@
-import { SxProps } from '@mui/system';
+import { SxProps } from '@mui/system/styleFunctionSx';
 
 export interface MenuItemData {
   uid?: string;

--- a/packages/mui-nested-menu/src/definitions.ts
+++ b/packages/mui-nested-menu/src/definitions.ts
@@ -1,3 +1,5 @@
+import { SxProps } from '@mui/system';
+
 export interface MenuItemData {
   uid?: string;
   label?: string;
@@ -5,4 +7,6 @@ export interface MenuItemData {
   rightIcon?: React.ReactNode;
   callback?: () => void;
   items?: MenuItemData[];
+  disabled?: boolean;
+  sx?: SxProps;
 }


### PR DESCRIPTION
Fix docs for correct yarn command
Fix typo `nesteMenuItemsFromObjectProps`
Add `sx` and `disabled` as fields in `MenuItemData` to allow finer control from `menuItemsData` prop