### PR TITLE
NestedDropdownProps should have array of MenuItemData objects

### DIFF
--- a/packages/mui-nested-menu/src/components/NestedDropdown.tsx
+++ b/packages/mui-nested-menu/src/components/NestedDropdown.tsx
@@ -7,7 +7,7 @@ import { MenuItemData } from '../definitions';
 
 interface NestedDropdownProps {
 	children?: React.ReactNode;
-	menuItemsData?: MenuItemData;
+	menuItemsData?: MenuItemData[];
 	onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 	ButtonProps?: Partial<ButtonProps>;
 	MenuProps?: Partial<MenuProps>;


### PR DESCRIPTION
Based on the documentation, the `menuItemsData` prop passed to the `NestedDropdown` is really an array of MenuItemData objects. This PR updates NestedDropdownProps. I noticed this when trying to work with `NestedDropdown` since Typescript threw an error for passing an array of MenuItemData objects to it.